### PR TITLE
Support version pinning

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,2 +1,2 @@
-docker_version: 18.03.0
+docker_version: ""
 docker_compose_enabled: no

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,1 +1,2 @@
+docker_version: 18.03.0
 docker_compose_enabled: no

--- a/molecule/default/playbook.yml
+++ b/molecule/default/playbook.yml
@@ -2,5 +2,7 @@
 - name: Converge
   hosts: all
   become: yes
+  vars:
+    docker_version: 18.03.0
   roles:
     - role: role-docker

--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -5,6 +5,8 @@ import testinfra.utils.ansible_runner
 testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
     os.environ['MOLECULE_INVENTORY_FILE']).get_hosts('all')
 
+DOCKER_VERSION = '18.03.0'
+
 
 def test_apt_repo(host):
     assert host.file(
@@ -30,3 +32,14 @@ def test_docker_hello_world(host):
 
 def test_docker_compose(host):
     assert not host.file("/usr/bin/docker-compose").exists
+
+
+def test_version_pinning(host):
+    f = host.file('/etc/apt/preferences.d/docker')
+
+    assert f.exists
+    assert f.user == 'root'
+    assert f.group == 'root'
+    assert f.mode == 0644
+
+    assert f.contains("Pin: version {}*".format(DOCKER_VERSION))

--- a/tasks/install/default.yml
+++ b/tasks/install/default.yml
@@ -20,6 +20,7 @@
   notify: update apt caches
 
 - name: configure APT preferences for version pinning
+  when: not docker_version == ""
   template:
     src: etc/apt/preferences.d/docker.j2
     dest: /etc/apt/preferences.d/docker

--- a/tasks/install/default.yml
+++ b/tasks/install/default.yml
@@ -19,12 +19,17 @@
       stable
   notify: update apt caches
 
-- meta: flush_handlers
+- name: configure APT preferences for version pinning
+  template:
+    src: etc/apt/preferences.d/docker.j2
+    dest: /etc/apt/preferences.d/docker
+    owner: root
+    group: root
+    mode: 0644
 
 - name: Installing docker
   apt:
     pkg: docker-ce
-    update_cache: no
     install_recommends: yes
   notify: restart docker
 

--- a/templates/etc/apt/preferences.d/docker.j2
+++ b/templates/etc/apt/preferences.d/docker.j2
@@ -1,0 +1,3 @@
+Package: docker-ce
+Pin: version {{ docker_version }}*
+Pin-Priority: 1000


### PR DESCRIPTION
This PR adds support for pinning the Docker package to a specific version via APT preferences.